### PR TITLE
ci: add integration test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  integration-test:
+    uses: Ultimate-Multisite/ultimate-multisite/.github/workflows/addon-integration-test.yml@main
+    with:
+      addon-slug: ultimate-multisite-mailster
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that calls the core plugin's reusable `addon-integration-test.yml` workflow
- On every push/PR, runs PHPUnit tests against a real WordPress Multisite environment with the core Ultimate Multisite plugin loaded as a dependency
- Part of the addon management infrastructure rollout

No code changes — CI only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added continuous integration workflow that automatically runs integration tests on code pushes to main and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->