### PR TITLE
chore: upgrade GitHub Actions from Node.js 20 to Node.js 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   ADDON_SLUG: ultimate-multisite-mailster
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-and-release:
@@ -19,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate release version
         run: |
@@ -64,7 +65,7 @@ jobs:
           coverage: none
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -84,7 +85,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ADDON_SLUG }}-zip
           path: ${{ env.ADDON_SLUG }}.zip
@@ -106,18 +107,18 @@ jobs:
 
     steps:
       - name: Checkout addon
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ env.ADDON_SLUG }}
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ env.ADDON_SLUG }}-zip
           path: ${{ env.ADDON_SLUG }}
 
       - name: Checkout deployment tool
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Ultimate-Multisite/addon-deployment-tool
           path: addon-deployment-tool


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions action versions to eliminate Node.js 20 deprecation warnings ahead of the June 2, 2026 forced migration deadline.

### Changes in `.github/workflows/deploy.yml`

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-node` | `@v4` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `actions/download-artifact` | `@v4` | `@v8` |
| `softprops/action-gh-release` | `@v2` (kept) | `@v2` + `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` |

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` is added at the workflow-level `env:` block, covering all jobs until upstream releases native Node 24 support.

`shivammathur/setup-php@v2` is already on Node 24 — no change needed.

`ci.yml` delegates entirely to a reusable workflow (`addon-integration-test.yml`) — no changes needed there.

## Verification

After merging, trigger a workflow run and confirm no Node.js 20 deprecation warnings appear in the annotations.

Resolves #10