### PR TITLE
fix: allow Jetpack autoloader 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
                 "php": ">=7.4.1",
                 "ext-json": "*",
                 "ext-curl": "*",
-                "automattic/jetpack-autoloader": "^3.0",
+                "automattic/jetpack-autoloader": "^3.0 || ^4.0 || ^5.0",
                 "wearerequired/traduttore-registry": "^2.0"
         },
         "require-dev": {


### PR DESCRIPTION
## Summary

- Allow `automattic/jetpack-autoloader` 5.x while preserving 3.x and 4.x compatibility.
- Unblocks Composer resolution with packages that already require Jetpack Autoloader 5.

## Verification

- `composer validate --no-check-publish`
- `composer update --dry-run --no-interaction` locked `automattic/jetpack-autoloader` v5.0.20
- `composer update --no-dev --dry-run --no-interaction` selected `automattic/jetpack-autoloader` v5.0.20 for runtime dependencies

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.35 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded support for Jetpack Autoloader versions 3, 4, and 5, giving Composer more flexibility when installing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->